### PR TITLE
Adding  border shadow and background to FeaturedPosts

### DIFF
--- a/components/Posts/FeaturedPosts/FeaturedPosts.module.css
+++ b/components/Posts/FeaturedPosts/FeaturedPosts.module.css
@@ -2,21 +2,16 @@
   width: 90%;
   margin: var(--size-8) auto;
   text-align: center;
+  border: 1px solid #6b7072;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  background-color: var(--color-blue-600);
 }
 
-
-.latest h2 {
-  font-size: var(--size-4);
-  color: var(--color-blue-800);
-  text-align: center;
-  font-size: 3rem; 
-  font-weight: normal; 
-  line-height: 3rem;
-  margin: 1.5rem;
-}
-
-@media (min-width: 768px) {
-  .latest h2 {
-    font-size: var(--size-8);
+@media (max-width: 320px) {
+  .latest {
+    width: 100%;
+    border: 1px solid #6b7072;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    background-color: var(--color-blue-600);
   }
 }


### PR DESCRIPTION
**1. Adding border**

Added solid 1px border of grey color around FeaturedPosts . 

**2. Adding box shadow**
Added _bottom_ box-shadow of 0.1 , and _top_ box-shadow of 0.06 .

**3. Adding background color**
Added background color of var(--color-blue-600) .

**4. Adding media query**
Added media query for mobile screen sizes for max-width of 320px .


_**320px:**_
![FeaturedPosts320px](https://user-images.githubusercontent.com/119621755/230606872-ed293240-22c9-4d58-b0ce-be15ce752730.png)

_**696px**_
![FeaturedPosts-696px](https://user-images.githubusercontent.com/119621755/230607165-001f6527-5e1d-4573-a182-51d3c62f493e.png)


_**Laptop size**_
![FeaturedPosts-laptopSize](https://user-images.githubusercontent.com/119621755/230607214-de13fd18-1ca4-4e22-a416-aa0f013092db.png)
