### PR TITLE
HotFix/Bug-Daily Updates on Porch Page && text in Daily Updates Box

### DIFF
--- a/components/PorchElements/PorchDailyUpdate/index.tsx
+++ b/components/PorchElements/PorchDailyUpdate/index.tsx
@@ -68,7 +68,7 @@ export const PorchDailyUpdate: React.FC<PorchDailyUpdateProps> = ({ porch, setPo
 				</p>
 				<div className="flex flex-col mt-2 border-4 border-gray-200 rounded-xl bg-gray-200">
 					<a href={`mailto:${porch.email}`} title={porch.email}>
-						<p className="pl-2 text-sm font-medium text-gray-900">
+						<p className="pl-2 text-sm font-medium text-gray-900 break-all">
 							<b>User Email: </b>
 							<span className="whitespace-normal hover:underline">
 								{porch.email}
@@ -82,7 +82,7 @@ export const PorchDailyUpdate: React.FC<PorchDailyUpdateProps> = ({ porch, setPo
 								: `//${porch.source}`
 						}
 						target="_blank"
-						className="pl-2 text-gray-900 text-sm font-medium"
+						className="pl-2 text-gray-900 text-sm font-medium break-all"
 					>
 						<b>Source: </b>
 						<span className="whitespace-normal hover:underline">

--- a/components/PorchElements/PorchHeader/index.tsx
+++ b/components/PorchElements/PorchHeader/index.tsx
@@ -12,7 +12,7 @@ interface PorchHeaderProps {
 }
 
 export const PorchHeader: React.FC<PorchHeaderProps> = ({ showForm, setShowForm }) => {
-	const { userInfo} = useContext(UserInfoContext);
+	const { userInfo } = useContext(UserInfoContext);
 
 	return (
 		<header className="flex flex-col mt-1">

--- a/components/PorchElements/PorchHeader/index.tsx
+++ b/components/PorchElements/PorchHeader/index.tsx
@@ -12,7 +12,7 @@ interface PorchHeaderProps {
 }
 
 export const PorchHeader: React.FC<PorchHeaderProps> = ({ showForm, setShowForm }) => {
-	const { userInfo } = useContext(UserInfoContext);
+	const { userInfo} = useContext(UserInfoContext);
 
 	return (
 		<header className="flex flex-col mt-1">

--- a/components/PorchElements/PorchList/index.tsx
+++ b/components/PorchElements/PorchList/index.tsx
@@ -20,15 +20,12 @@ export const PorchList: React.FC<PorchListProps> = ({ porchs, setPorchs }) => {
 		setDailyUpdates(porchs);
 	}, [porchs]);
 
-	const sortPorchbyDate = useMemo(() => {
-		return dailyUpdates.slice().sort((a, b) => {
-			return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-		});
-	}, [dailyUpdates]);
-
 	const filteringUpdatesPerUser = useMemo(() => {
-		return dailyUpdates.filter((porch) => porch.email === userInfo?.email);
-	}, [dailyUpdates, userInfo?.email]);
+		const updates = filtered 
+			? dailyUpdates.filter((porch) => porch.email === userInfo?.email)
+			: dailyUpdates; 
+			return updates.slice().sort((a,b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+	}, [dailyUpdates, userInfo?.email, filtered]);
 
 	useEffect(() => {
 		const fetchLearningDays = async () => {
@@ -49,10 +46,14 @@ export const PorchList: React.FC<PorchListProps> = ({ porchs, setPorchs }) => {
 	}, [userInfo?.email]);
 
 	const handleFiltering = () => {
-		setDailyUpdates(filtered ? porchs : filteringUpdatesPerUser);
-		setButtonTitle(filtered ? "All Daily Updates" : "Track Your Daily Updates");
-		setFiltered(!filtered);
-	};
+		setFiltered((prevState) => {
+		  const newFiltered = !prevState;
+		  setButtonTitle(
+			newFiltered ? "All Daily Updates" : "Track Your Daily Updates"
+		  );
+		  return newFiltered;
+		});
+	  };
 
 	return (
 		<section className="py-1 sm:py-1 lg:py-1 border-y-4">
@@ -77,9 +78,13 @@ export const PorchList: React.FC<PorchListProps> = ({ porchs, setPorchs }) => {
 							) : null}
 						</div>
 						<div className="mt-6 space-y-3">
-							{sortPorchbyDate.map((porch) => (
-								<PorchDailyUpdate key={porch.id + Math.random()} porch={porch} setPorchs={setPorchs} />
-							))}
+						{filteringUpdatesPerUser.map((porch) => (
+                			<PorchDailyUpdate
+                 				key={porch.id + Math.random()}
+                  				porch={porch}
+                  				setPorchs={setPorchs}
+                			/>
+              			))}
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
The track learning days button has backwards logic. When clicked the text in the button doesn’t actually represent the task being completed, it's backwards. Switch the logic so it shows the correct text for fetching learning days.

Also fixed the text not to go outside of Daily Updates box when in mobile view.

