### PR TITLE
Hot Fix - porch cell width for mobile view

### DIFF
--- a/components/PorchElements/PorchDailyUpdate/index.tsx
+++ b/components/PorchElements/PorchDailyUpdate/index.tsx
@@ -66,7 +66,7 @@ export const PorchDailyUpdate: React.FC<PorchDailyUpdateProps> = ({ porch, setPo
 				<p className="text-xl text-transparent bg-clip-text bg-gradient-to-r from-blue-700 via-blue-500 to-blue-800">
 					<b>Daily Update</b>
 				</p>
-				<div className="flex flex-col mt-2 border-4 border-gray-200 rounded-xl bg-gray-200">
+				<div className="flex flex-col pr-1 mt-2 border-4 border-gray-200 rounded-xl bg-gray-200">
 					<a href={`mailto:${porch.email}`} title={porch.email}>
 						<p className="pl-2 text-sm font-medium text-gray-900 break-all">
 							<b>User Email: </b>

--- a/components/PorchElements/PorchList/index.tsx
+++ b/components/PorchElements/PorchList/index.tsx
@@ -57,10 +57,10 @@ export const PorchList: React.FC<PorchListProps> = ({ porchs, setPorchs }) => {
 
 	return (
 		<section className="py-1 sm:py-1 lg:py-1 border-y-4">
-			<div className="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+			<div className=" mx-auto max-w-7xl sm:px-6 lg:px-8">
 				<div className="max-w- mx-auto overflow-hidden bg-gray-100 rounded-xl">
-					<div className="px-4 py-5 sm:p-6">
-						<div>
+					<div className="py-5 sm:p-6">
+						<div className="ml-2">
 							<p className="text-lg font-bold text-gray-900">Daily Highlights</p>
 							<p className="mt-1 text-sm font-medium text-gray-500">Growth and Learning News</p>
 							{userInfo?.email ? (


### PR DESCRIPTION
Changed padding and margin for porch cell so it doesn't look small on mobile screen. 
<img width="1710" alt="Screenshot 2024-11-13 at 4 28 25 PM" src="https://github.com/user-attachments/assets/077f996f-7844-49b5-9ae9-3be0305410bb">

