### PR TITLE
Fix/Grip not working on Weekly Goals Form 

### DIFF
--- a/pages/porch.tsx
+++ b/pages/porch.tsx
@@ -59,6 +59,7 @@ const PorchPage: NextPage<PorchPageProps> = ({ initialPorchs }) => {
 
 
     const handleMouseDown = (e: MouseEvent<HTMLDivElement>) => {
+		if ((e.target as HTMLElement).tagName === 'SELECT') return;
         setDragging( true )
         setOffset({
             x: e.clientX - position.x,


### PR DESCRIPTION
When pressed on Check your stats and update your goals /Edit goal on page Porch, there was an issue with the grip functionality that occurs after clicking the "Options" button. This problem only occurred when in Safari Browser. 
I fixed it by adding IF condition that checks whether the user clicked on a <select> element. If the clicked element is a <select>, the function exits early (due to return) and skips the drag logic.
Now it's working properly both in Safari and Chrome Browsers. 