### PR TITLE
Fixed Blog Drop Down not closing on click

### DIFF
--- a/Types/Navigation/index.tsx
+++ b/Types/Navigation/index.tsx
@@ -2,3 +2,11 @@ export interface NavigationProps {
 	categories: string[];
     userInfo?: any;
   }
+
+
+export interface DropDownMenuProps {
+    label: string;
+    items: string[];
+    onSelect: (item: string) => void;
+    className?: string; 
+}

--- a/components/DropDown/index.tsx
+++ b/components/DropDown/index.tsx
@@ -1,38 +1,51 @@
-import { FC, useState, useEffect, useRef } from 'react';
+import { FC, useState, useRef, useEffect } from 'react';
+import { DropDownMenuProps } from '@/Types/Navigation';
 
-interface DropDownProps {
-    label: string;
-    items: string[];
-    handleClick: (item: string) => void;
-}
-
-export const DropDown: FC<DropDownProps> = ({ label, items, handleClick }) => {
+export const DropDownMenu: FC<DropDownMenuProps> = ({ label, items, onSelect, className }) => {
     const [isOpen, setIsOpen] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
 
+    const toggleMenu = () => setIsOpen((prev) => !prev)
+
+    const handleItemClick = (item: string) => {
+      onSelect(item);
+      setIsOpen(false); 
+  }
+
+    useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+          setIsOpen(false);
+        }
+      };
+      
+      if (isOpen) {
+        document.addEventListener("mousedown", handleClickOutside);
+      }
+
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }, [isOpen]);
+
     return (
-        <div ref={dropdownRef} 
-        className="relative inline-block group"
-        onMouseEnter={() => setIsOpen(true)}
-        onMouseLeave={() => setIsOpen(false)}
+        <div ref={dropdownRef} className="relative inline-block group"
         >
             <button
-                onClick={() => setIsOpen((prev) => !prev)} 
+                onClick={toggleMenu} 
                 aria-haspopup="true"
                 aria-expanded={isOpen}
             >
                 {label}
             </button>
-            {(isOpen || dropdownRef.current?.matches(':hover')) && (
-
+            {isOpen && (
               <ul className="absolute left-0 mt-2 bg-white shadow-xl w-48 z-50 flex flex-col rounded-lg border border-gray-300">
-                    {items.map((item, index) => (
+                    {items.map((item) => (
                         <li
-                            key={index}
+                            key={item}
                             className="block px-4 py-2 cursor-pointer border-b border-gray-200 hover:bg-gray-100 last:border-none"
                             onClick={() => {
-                                handleClick(item); 
-                                setIsOpen(false);
+                                handleItemClick(item); 
                             }}
                         >
                             {item}

--- a/components/Posts/BlogDropDown/index.tsx
+++ b/components/Posts/BlogDropDown/index.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
-import { DropDown } from '@/components/DropDown'
+import { DropDownMenu } from '@/components/DropDown'
 import { useCategoryHook } from '@/lib/hooks/useCategoryHook'
 import { CatProps } from "../BlogMenuCat"
 
@@ -25,10 +25,10 @@ export const BlogDropDown: FC<CatProps> = ({ categories, onSearch }) => {
     };
 
     return (
-        <DropDown
+        <DropDownMenu
             label="Blog" 
             items={categories}
-            handleClick={handleItemClick}
+            onSelect={handleItemClick}
         />
     );
 };


### PR DESCRIPTION
The Blog Drop Down is now closing when the user selects a Category from the menu && closing when clicked outside of it. 

Moved DropDownMenuProps to Types/Navigation/index.ts for better organization, and renamed the function from handleClick to onSelect for improved clarity.